### PR TITLE
herokuから移動して動かす

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,8 @@
-const LINE_CHANNEL_ACCESS_TOKEN = process.env.LINE_CHANNEL_ACCESS_TOKEN;
+//const LINE_CHANNEL_ACCESS_TOKEN = process.env.LINE_CHANNEL_ACCESS_TOKEN;
+
+var fs = require('fs');
+var obj = JSON.parse(fs.readFileSync('./token.json', 'utf8'));
+const LINE_CHANNEL_ACCESS_TOKEN = obj.line.Channel_Access_Token;
 
 // -----------------------------------------------------------------------------
 // モジュールのインポート

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "export PORT=3008;./node_modules/babel-cli/bin/babel-node.js index.js",
+    "start": "export PORT=3008;node index.js"
   },
   "keywords": [],
   "author": "Naoshi Ooba",


### PR DESCRIPTION
社内サーバで動かすように、tokenをjsonファイルから読む仕様にしました（jsonファイルはignoreされてます） @taiju59 